### PR TITLE
chore(init): remove now unsupported force option

### DIFF
--- a/nvm/source/init.sls
+++ b/nvm/source/init.sls
@@ -14,7 +14,6 @@ https://github.com/creationix/nvm.git:
   git.latest:
     - rev: master
     - target: {{ install_path }}
-    - force: True
     - require:
       - pkg: nvm_packages
 


### PR DESCRIPTION
Seems like the `force` option doesn't exist anymore.
There are now 4 of them:

> force_checkout
> : False
>     When checking out the local branch, the state will fail if there are unwritten changes. Set this argument to True to discard unwritten changes when checking out.


> force_clone
> : False
>     If the target directory exists and is not a git repository, then this state will fail. Set this argument to True to remove the contents of the target directory and clone the repo into it.


> force_fetch
> : False
> 
>   If a fetch needs to be performed, non-fast-forward fetches will cause this state to fail. Set this argument to True to force the fetch even if it is a non-fast-forward update.
> 
>   New in version 2015.8.0.


> force_reset
> : False
>     If the update is not a fast-forward, this state will fail. Set this argument to True to force a hard-reset to the remote revision in these cases.

I don't know which one this option was set for. In the meantime, in my case setting it to `False` worked, hence this PR.